### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -1,5 +1,7 @@
 name: GitHub Actions Demo
 run-name: ${{ github.actor }} is testing out GitHub Actions 🚀
+permissions:
+  contents: read
 on: [push]
 jobs:
   Explore-GitHub-Actions:


### PR DESCRIPTION
Potential fix for [https://github.com/Alcheri/URLtitle/security/code-scanning/2](https://github.com/Alcheri/URLtitle/security/code-scanning/2)

In general, the fix is to explicitly set minimal `GITHUB_TOKEN` permissions either at the workflow root or for the specific job. Since there is only one job and it only needs to read repository contents (for `actions/checkout`) and list files, we can safely set `contents: read` at the workflow level. This documents that the workflow does not require any write permissions and ensures that if repository defaults change later, the workflow will still have limited privileges.

The best, minimal-impact change is to add a `permissions` block near the top of `.github/workflows/github-actions-demo.yml`, at the root level (same indentation as `name`, `run-name`, and `on`). We’ll set `contents: read`, which is the least privilege necessary for `actions/checkout@v4` to function in this workflow. No imports or additional methods are required because this is a YAML configuration file for GitHub Actions.

Concretely:
- Edit `.github/workflows/github-actions-demo.yml`.
- Insert a `permissions:` block after the `run-name` line (line 2), with `contents: read` indented two spaces under it.
- Leave the rest of the workflow unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
